### PR TITLE
Use host prefix PYTHON (instead of build prefix)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,12 +4,12 @@ package:
 
 source:
   url: https://earthbyte.org/webdav/ftp/earthbyte/pygplates/pygplates_0.39.0_src.tar.bz2
-  sha256: 49ba8490f46d62cbe13140bdfbb5a1bf31917fbf3d788fda0b14148a0c5df7cc
+  sha256: 74271fe78c8f38d71d3453654d9c563f21ee38e6c12525c844f1587f27335d6b
 
 build:
   skip: True  # [py<37]
   skip: True  # [win and vc<14]
-  number: 4
+  number: 5
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Cross-compiled linux-aarch64 and linux-ppc64le are not finding numpy in build prefix (but cross-compiled osx-arm64 is finding numpy). So instead this PR is using host prefix via PYTHON env var (for all platforms).